### PR TITLE
More cleaners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.0] - 2022-11-21
+### Added
+- Add cleaner for Load Balancer Pools
+- Add cleaner for DNAT rules
 
+
+## [0.1.0] - 2022-11-21
 
 
 [Unreleased]: https://github.com/giantswarm/cluster-api-cleaner-cloud-director/compare/v0.1.0...HEAD

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
-
 ## [Unreleased]
 
 ### Added
-- Add cleaner for Load Balancer Pools
-- Add cleaner for DNAT rules
+
+- Add cleaner for Load Balancer Pools.
+- Add cleaner for DNAT rules.
 
 
 ## [0.1.0] - 2022-11-21

--- a/controllers/vcdcluster_controller.go
+++ b/controllers/vcdcluster_controller.go
@@ -18,6 +18,7 @@ package controllers
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -122,6 +123,10 @@ func (r *VCDClusterReconciler) reconcileDelete(ctx context.Context, log logr.Log
 			"expectedLabelKey", key.CapiClusterLabelKey,
 			"existingLabels", vcdCluster.Labels)
 		return ctrl.Result{}, nil
+	}
+	if len(vcdCluster.Status.InfraId) == 0 {
+		e := fmt.Errorf(".status.infraId is not populated on the cluster: %s", vcdCluster.Name)
+		return ctrl.Result{Requeue: true, RequeueAfter: time.Second * 10}, microerror.Mask(e)
 	}
 
 	vcdClient, err := vcd.GetVCDClient(ctx, r.Client, vcdCluster, log)

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,10 @@ module github.com/giantswarm/cluster-api-cleaner-cloud-director
 go 1.18
 
 require (
+	github.com/antihax/optional v1.0.0
 	github.com/giantswarm/microerror v0.4.0
 	github.com/go-logr/logr v1.2.2
+	github.com/peterhellberg/link v1.1.0
 	github.com/pkg/errors v0.9.1
 	github.com/vmware/cloud-provider-for-cloud-director v0.0.0-20221104192532-8946fef8b046
 	github.com/vmware/cluster-api-provider-cloud-director v0.0.0-20221104233019-99b9d0ca0b3f
@@ -20,7 +22,6 @@ require (
 	cloud.google.com/go v0.99.0 // indirect
 	github.com/PuerkitoBio/purell v1.1.1 // indirect
 	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 // indirect
-	github.com/antihax/optional v1.0.0 // indirect
 	github.com/apparentlymart/go-cidr v1.1.0 // indirect
 	github.com/araddon/dateparse v0.0.0-20190622164848-0fb0a474d195 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
@@ -54,7 +55,6 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
-	github.com/peterhellberg/link v1.1.0 // indirect
 	github.com/prometheus/client_golang v1.12.1 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/common v0.32.1 // indirect

--- a/main.go
+++ b/main.go
@@ -100,6 +100,8 @@ func mainE(ctx context.Context) error {
 	cleaners := []cleaner.Cleaner{
 		cleaner.NewVolumeCleaner(mgr.GetClient()),
 		cleaner.NewVirtualServiceCleaner(mgr.GetClient()),
+		cleaner.NewLBPoolCleaner(mgr.GetClient()),
+		cleaner.NewDNATCleaner(mgr.GetClient()),
 	}
 
 	if err = (&controllers.VCDClusterReconciler{

--- a/pkg/cleaner/cleaner.go
+++ b/pkg/cleaner/cleaner.go
@@ -1,3 +1,19 @@
+/*
+
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package cleaner
 
 import (

--- a/pkg/cleaner/dnats.go
+++ b/pkg/cleaner/dnats.go
@@ -1,3 +1,19 @@
+/*
+
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package cleaner
 
 import (

--- a/pkg/cleaner/dnats.go
+++ b/pkg/cleaner/dnats.go
@@ -1,0 +1,63 @@
+package cleaner
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/giantswarm/microerror"
+	"github.com/go-logr/logr"
+	"github.com/vmware/cloud-provider-for-cloud-director/pkg/vcdsdk"
+	capvcd "github.com/vmware/cluster-api-provider-cloud-director/api/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type DNATCleaner struct {
+	cli client.Client
+}
+
+func NewDNATCleaner(cli client.Client) *DNATCleaner {
+	return &DNATCleaner{cli: cli}
+}
+
+// force implementing Cleaner interface
+var _ Cleaner = &DNATCleaner{}
+
+func (lbc *DNATCleaner) Clean(ctx context.Context, log logr.Logger, vcdClient *vcdsdk.Client, c *capvcd.VCDCluster) (bool, error) {
+	log = log.WithName("DNATCleaner")
+	gateway, err := vcdsdk.NewGatewayManager(ctx, vcdClient, c.Spec.OvdcNetwork, c.Spec.LoadBalancerConfigSpec.VipSubnet)
+	if err != nil {
+		return false, err
+	}
+	edgeNatRules, _, err := vcdClient.APIClient.EdgeGatewayNatRulesApi.GetNatRules(ctx, 128, gateway.GatewayRef.Id, c.Spec.Org, nil)
+	if err != nil {
+		return false, err
+	}
+	infraId := c.Status.InfraId
+	if len(infraId) == 0 {
+		return true, microerror.Mask(fmt.Errorf(".status.infraId is not populated on the cluster: %s", c.Name))
+	}
+	if len(edgeNatRules.Values) == 0 {
+		log.Info("there is nothing to do")
+		return false, nil
+	}
+	deleted := 0
+
+	for _, enr := range edgeNatRules.Values {
+		enrName := enr.Name
+		// if the name of the DNAT rule contains the cluster's infraId, delete this item
+		if strings.Contains(enrName, infraId) {
+			log.Info(fmt.Sprintf("deleting DNAT: %s", enrName))
+			err = gateway.DeleteDNATRule(ctx, enrName, false)
+			if err != nil {
+				return false, err
+			}
+			deleted++
+		}
+	}
+	if deleted > 0 {
+		log.Info(fmt.Sprintf("%d DNATs were deleted", deleted))
+	}
+
+	return false, nil
+}

--- a/pkg/cleaner/dnats.go
+++ b/pkg/cleaner/dnats.go
@@ -47,9 +47,6 @@ func (lbc *DNATCleaner) Clean(ctx context.Context, log logr.Logger, vcdClient *v
 	if err != nil {
 		return false, err
 	}
-	if err := vcdClient.RefreshBearerToken(); err != nil {
-		return false, err
-	}
 	org, err := vcdClient.VCDClient.GetOrgByName(vcdClient.ClusterOrgName)
 	if err != nil {
 		return false, microerror.Mask(err)

--- a/pkg/cleaner/lb_pools.go
+++ b/pkg/cleaner/lb_pools.go
@@ -1,3 +1,19 @@
+/*
+
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package cleaner
 
 import (

--- a/pkg/cleaner/lb_pools.go
+++ b/pkg/cleaner/lb_pools.go
@@ -1,0 +1,58 @@
+package cleaner
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/giantswarm/microerror"
+	"github.com/go-logr/logr"
+	"github.com/vmware/cloud-provider-for-cloud-director/pkg/vcdsdk"
+	capvcd "github.com/vmware/cluster-api-provider-cloud-director/api/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type LBPoolCleaner struct {
+	cli client.Client
+}
+
+func NewLBPoolCleaner(cli client.Client) *LBPoolCleaner {
+	return &LBPoolCleaner{cli: cli}
+}
+
+// force implementing Cleaner interface
+var _ Cleaner = &LBPoolCleaner{}
+
+func (lbc *LBPoolCleaner) Clean(ctx context.Context, log logr.Logger, vcdClient *vcdsdk.Client, c *capvcd.VCDCluster) (bool, error) {
+	log = log.WithName("LBPoolCleaner")
+	gateway, err := vcdsdk.NewGatewayManager(ctx, vcdClient, c.Spec.OvdcNetwork, c.Spec.LoadBalancerConfigSpec.VipSubnet)
+	if err != nil {
+		return false, err
+	}
+	lbps, err := vcdClient.VCDClient.GetAllAlbPools(gateway.GatewayRef.Id, nil)
+	if err != nil {
+		return false, err
+	}
+	infraId := c.Status.InfraId
+	if len(infraId) == 0 {
+		return true, microerror.Mask(fmt.Errorf(".status.infraId is not populated on the cluster: %s", c.Name))
+	}
+	deleted := 0
+	for _, lbp := range lbps {
+		lbName := lbp.NsxtAlbPool.Name
+		// if the name of the load balancer pool contains the cluster's infraId, delete this lb pool
+		if strings.Contains(lbName, infraId) {
+			log.Info(fmt.Sprintf("deleting load balancer pool: %s", lbName))
+			err = gateway.DeleteLoadBalancerPool(ctx, lbName, false)
+			if err != nil {
+				return false, err
+			}
+			deleted++
+		}
+	}
+	if deleted > 0 {
+		log.Info(fmt.Sprintf("%d load balancer pool were deleted", deleted))
+	}
+
+	return false, nil
+}

--- a/pkg/cleaner/virtualservices.go
+++ b/pkg/cleaner/virtualservices.go
@@ -1,3 +1,19 @@
+/*
+
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package cleaner
 
 import (

--- a/pkg/cleaner/virtualservices.go
+++ b/pkg/cleaner/virtualservices.go
@@ -21,7 +21,8 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/cluster-api-cleaner-cloud-director/pkg/vcd"
+
 	"github.com/go-logr/logr"
 	"github.com/vmware/cloud-provider-for-cloud-director/pkg/vcdsdk"
 	capvcd "github.com/vmware/cluster-api-provider-cloud-director/api/v1beta1"
@@ -41,7 +42,7 @@ var _ Cleaner = &VirtualServiceCleaner{}
 
 func (lbc *VirtualServiceCleaner) Clean(ctx context.Context, log logr.Logger, vcdClient *vcdsdk.Client, c *capvcd.VCDCluster) (bool, error) {
 	log = log.WithName("VirtualServiceCleaner")
-	gateway, err := vcdsdk.NewGatewayManager(ctx, vcdClient, c.Spec.OvdcNetwork, c.Spec.LoadBalancerConfigSpec.VipSubnet)
+	gateway, err := vcd.GetGateway(ctx, vcdClient, c)
 	if err != nil {
 		return false, err
 	}
@@ -50,9 +51,6 @@ func (lbc *VirtualServiceCleaner) Clean(ctx context.Context, log logr.Logger, vc
 		return false, err
 	}
 	infraId := c.Status.InfraId
-	if len(infraId) == 0 {
-		return true, microerror.Mask(fmt.Errorf(".status.infraId is not populated on the cluster: %s", c.Name))
-	}
 	deleted := 0
 	for _, vSvc := range vSvcs {
 		svcName := vSvc.NsxtAlbVirtualService.Name

--- a/pkg/cleaner/virtualservices.go
+++ b/pkg/cleaner/virtualservices.go
@@ -40,7 +40,6 @@ func (lbc *VirtualServiceCleaner) Clean(ctx context.Context, log logr.Logger, vc
 	deleted := 0
 	for _, vSvc := range vSvcs {
 		svcName := vSvc.NsxtAlbVirtualService.Name
-		//todo: pools
 		// if the name of the virtual service contains the cluster's infraId, delete this virtual service
 		if strings.Contains(svcName, infraId) {
 			log.Info(fmt.Sprintf("deleting virtual service: %s", svcName))

--- a/pkg/cleaner/volumes.go
+++ b/pkg/cleaner/volumes.go
@@ -1,3 +1,19 @@
+/*
+
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package cleaner
 
 import (

--- a/pkg/key/key.go
+++ b/pkg/key/key.go
@@ -1,11 +1,22 @@
+/*
+
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package key
 
 const (
-	ClusterTagPrefix     = "giant_swarm_cluster"
 	CapiClusterLabelKey  = "cluster.x-k8s.io/cluster-name"
 	CleanerFinalizerName = "cluster-api-cleaner-cloud-director.finalizers.giantswarm.io"
-
-	LoadBalancerProvisioningStatusActive = "ACTIVE"
-	LoadBalancerProvisioningStatusError  = "ERROR"
-	VolumeStatusDeleting                 = "deleting"
 )

--- a/pkg/vcd/vcd_utils.go
+++ b/pkg/vcd/vcd_utils.go
@@ -76,3 +76,11 @@ func GetVCDClient(ctx context.Context, c client.Client, vcdCluster *capvcd.VCDCl
 	}
 	return workloadVCDClient, nil
 }
+
+func GetGateway(ctx context.Context, vcdClient *vcdsdk.Client, vcdCluster *capvcd.VCDCluster) (*vcdsdk.GatewayManager, error) {
+	gateway, err := vcdsdk.NewGatewayManager(ctx, vcdClient, vcdCluster.Spec.OvdcNetwork, vcdCluster.Spec.LoadBalancerConfigSpec.VipSubnet)
+	if err != nil {
+		return nil, err
+	}
+	return gateway, nil
+}

--- a/pkg/vcd/vcd_utils.go
+++ b/pkg/vcd/vcd_utils.go
@@ -18,6 +18,11 @@ package vcd
 
 import (
 	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/peterhellberg/link"
 
 	"strings"
 
@@ -62,6 +67,7 @@ func getUserCredentialsForCluster(ctx context.Context, cli client.Client, define
 	return userCredentials, nil
 }
 
+// GetVCDClient a helper function for initializing vcd api client, it gets the credentials from the k8s secret
 func GetVCDClient(ctx context.Context, c client.Client, vcdCluster *capvcd.VCDCluster, log logr.Logger) (*vcdsdk.Client, error) {
 	userCreds, err := getUserCredentialsForCluster(ctx, c, vcdCluster.Spec.UserCredentialsContext)
 	if err != nil {
@@ -77,10 +83,48 @@ func GetVCDClient(ctx context.Context, c client.Client, vcdCluster *capvcd.VCDCl
 	return workloadVCDClient, nil
 }
 
+// GetGateway a helper function that creates and returns GatewayManager
 func GetGateway(ctx context.Context, vcdClient *vcdsdk.Client, vcdCluster *capvcd.VCDCluster) (*vcdsdk.GatewayManager, error) {
 	gateway, err := vcdsdk.NewGatewayManager(ctx, vcdClient, vcdCluster.Spec.OvdcNetwork, vcdCluster.Spec.LoadBalancerConfigSpec.VipSubnet)
 	if err != nil {
 		return nil, err
 	}
 	return gateway, nil
+}
+
+// GetCursor handles the paging mechanism for queries that may return a lot of items
+// https://github.com/vmware/cloud-provider-for-cloud-director/blob/v1.2.0/pkg/vcdsdk/gateway.go#L199
+func GetCursor(resp *http.Response) (string, error) {
+	cursorURI := ""
+	for _, linklet := range resp.Header["Link"] {
+		for _, l := range link.Parse(linklet) {
+			if l.Rel == "nextPage" {
+				cursorURI = l.URI
+				break
+			}
+		}
+		if cursorURI != "" {
+			break
+		}
+	}
+	if cursorURI == "" {
+		return "", nil
+	}
+
+	u, err := url.Parse(cursorURI)
+	if err != nil {
+		return "", fmt.Errorf("unable to parse cursor URI [%s]: [%v]", cursorURI, err)
+	}
+
+	cursorStr := ""
+	keyMap, err := url.ParseQuery(u.RawQuery)
+	if err != nil {
+		return "", fmt.Errorf("unable to parse raw query [%s]: [%v]", u.RawQuery, err)
+	}
+
+	if cursorStrList, ok := keyMap["cursor"]; ok {
+		cursorStr = cursorStrList[0]
+	}
+
+	return cursorStr, nil
 }

--- a/pkg/vcd/vcd_utils.go
+++ b/pkg/vcd/vcd_utils.go
@@ -1,3 +1,19 @@
+/*
+
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package vcd
 
 import (


### PR DESCRIPTION
Add cleaners for:
- edge gateway > load balancer > pools
- edge gateway > services > NAT

~TODO:
fix the rbac or use a different way to delete the dnat rules, because I am getting this:~
```
edgeNatRules, _, err := vcdClient.APIClient.EdgeGatewayNatRulesApi.GetNatRules(ctx, 128, gateway.GatewayRef.Id, c.Spec.Org, nil)
err ~ {"minorErrorCode":"ACCESS_TO_RESOURCE_IS_FORBIDDEN","message":"Access is forbidden","stackTrace":null}
```
this ^ got fixed by https://github.com/giantswarm/cluster-api-cleaner-cloud-director/pull/9/commits/6776d7a0cad88f26b0acb9f0a7b5ae7be1930c39

## Checklist

- [x] Update changelog in CHANGELOG.md.
