### PR TITLE
Add logo&icon for Chart.yaml

### DIFF
--- a/helm/cluster-api-cleaner-cloud-director/Chart.yaml
+++ b/helm/cluster-api-cleaner-cloud-director/Chart.yaml
@@ -7,8 +7,8 @@ apiVersion: v1
 annotations:
   application.giantswarm.io/team: "rocket"
   config.giantswarm.io/version: 1.x.x
+  ui.giantswarm.io/logo: https://s.giantswarm.io/app-icons/vmware-cloud-director/1/logo_light.png
 restrictions:
   compatibleProviders:
     - cloud-director
-# todo:
-# icon: https://s.giantswarm.io/app-icons/cloud-director/1/light.svg
+icon: https://s.giantswarm.io/app-icons/vmware-cloud-director/1/logo_light.png


### PR DESCRIPTION
Piggybacking on https://github.com/giantswarm/cluster-cloud-director/pull/76

The cleaner for openstack also has the same logo as the infra provider itself.

Signed-off-by: Jiri Kremser <jiri.kremser@gmail.com>

## Checklist

- [ ] Update changelog in CHANGELOG.md. (imho too small to be able to fly under the radar)
