### PR TITLE
Add use of default/runtime seccomp profile.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add cleaner for Application Port Profiles.
 - Add `compatibleProviders` to `Chart.yaml`.
+- Add use of runtime/default seccomp profile.
 
 ## [0.2.0] - 2022-11-24
 

--- a/helm/cluster-api-cleaner-cloud-director/templates/deployment.yaml
+++ b/helm/cluster-api-cleaner-cloud-director/templates/deployment.yaml
@@ -24,6 +24,9 @@ spec:
       securityContext:
         runAsUser: {{ .Values.pod.user.id }}
         runAsGroup: {{ .Values.pod.group.id }}
+        {{- with .Values.podSecurityContext }}
+          {{- . | toYaml | nindent 8 }}
+        {{- end }}
       containers:
       - name: {{ .Chart.Name }}
         image: "{{ .Values.registry.domain }}/{{ .Values.image.name }}:{{ .Values.image.tag }}"
@@ -33,6 +36,10 @@ spec:
         - --enable-leader-election
         - --management-cluster={{ .Values.managementCluster }}
         - -v={{ .Values.logLevel }}
+        securityContext:
+          {{- with .Values.securityContext }}
+            {{- . | toYaml | nindent 10 }}
+          {{- end }}
         resources:
           requests:
             cpu: 100m

--- a/helm/cluster-api-cleaner-cloud-director/templates/psp.yaml
+++ b/helm/cluster-api-cleaner-cloud-director/templates/psp.yaml
@@ -2,6 +2,8 @@ apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ include "resource.psp.name" . }}
+  annotations:
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'runtime/default'
   labels:
     {{- include "labels.common" . | nindent 4 }}
 spec:

--- a/helm/cluster-api-cleaner-cloud-director/values.yaml
+++ b/helm/cluster-api-cleaner-cloud-director/values.yaml
@@ -14,3 +14,13 @@ pod:
     id: 1000
   group:
     id: 1000
+
+# Add seccomp to pod security context
+podSecurityContext:
+  seccompProfile:
+    type: RuntimeDefault
+
+# Add seccomp to container security context
+securityContext:
+  seccompProfile:
+    type: RuntimeDefault


### PR DESCRIPTION
Could you let me know whether this will work for CAPI clusters? 

I've modified the container and pod securitycontexts to let this application make use of the runtime/default seccomp profile. During testing this did not seem to interrupt any functionality. Please confirm this if possible.
This is done in light of:

https://github.com/giantswarm/roadmap/issues/259

Drop a message on slack if you've got questions.