### PR TITLE
update nancy with additional CVEs

### DIFF
--- a/.nancy-ignore
+++ b/.nancy-ignore
@@ -4,4 +4,10 @@
 
 # This requires apiserver v0.26.0 but there is no compatible cluster-api version yet
 sonatype-2022-6522 until=2023-06-01
-CVE-2020-8561 until=2023-06-01
+CVE-2020-8561 until=2024-01-01
+
+# pkg:net@0.7.0 Improper Neutralization of Input During Web Page Generation
+CVE-2023-3978
+
+# pkg:grpc@v1.40.0 gRPC HTTP2 header size exceeded error
+CVE-2023-32731

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-
 ## [Unreleased]
+
+### Changed
+
+- Extend ignore for CVE-2020-8561.
+- Ignore CVE-2023-3978 & CVE-2023-32731.
 
 ## [0.3.0] - 2023-05-02
 


### PR DESCRIPTION
This PR ignores the following CVEs:

- CVE-2020-8561 (extend existing ignore)
- CVE-2023-3978 - Improper Neutralization of Input During Web Page Generation
  - XSS bug which doesn't affect this repo.
- CVE-2023-29401 - gRPC HTTP2 header size exceeded error
  - [we already ignore this everywhere](https://github.com/search?q=org%3Agiantswarm+CVE-2023-32731&type=code)

## Checklist

- [x] Update changelog in CHANGELOG.md.
