### PR TITLE
Configure gsoci.azurecr.io as the registry to use by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+
 - PSS compliancy
+
 ### Changed
 
 - Configure `gsoci.azurecr.io` as the default container image registry.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-
 ### Added
-
 - PSS compliancy
+### Changed
+
+- Configure `gsoci.azurecr.io` as the default container image registry.
 
 ## [0.3.1] - 2023-08-24
 
@@ -18,7 +19,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Extend ignore for CVE-2020-8561.
 - Ignore CVE-2023-3978 & CVE-2023-32731.
-
 
 ## [0.3.0] - 2023-05-02
 
@@ -35,7 +35,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add cleaner for Load Balancer Pools.
 - Add cleaner for DNAT rules.
-
 
 ## [0.1.0] - 2022-11-21
 

--- a/helm/cluster-api-cleaner-cloud-director/values.yaml
+++ b/helm/cluster-api-cleaner-cloud-director/values.yaml
@@ -5,7 +5,7 @@ image:
   name: "giantswarm/cluster-api-cleaner-cloud-director"
   tag: "[[ .Version ]]"
 registry:
-  domain: docker.io
+  domain: gsoci.azurecr.io
 
 logLevel: 0
 


### PR DESCRIPTION
Towards

- https://github.com/giantswarm/roadmap/issues/3017

This PR replaces any occurrence of `docker.io` in `values.yaml` files with `gsoci.azurecr.io`,
to make the new ACR registry the default one.
